### PR TITLE
fix: render join/leave entries as <div> so #chattext p locators work

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1,5 +1,17 @@
+/*
+ * The join/leave entries are rendered as <div> rather than <p> so test
+ * locators that target real chat (`#chattext p`) don't trip on them.
+ * Core (pad/chat.css) and the colibris skin both style `#chattext p`
+ * directly though — mirror those rules here so the entries still look
+ * flush with regular chat lines. Padding matches the colibris override
+ * (4px 10px) since that's the default shipped skin.
+ */
 #chattext .ep_chat_log_join_leave-join,
 #chattext .ep_chat_log_join_leave-leave {
+  padding: 4px 10px;
+  overflow-x: hidden;
+  white-space: pre-wrap;
+  word-wrap: break-word;
   font-size: smaller;
   font-style: italic;
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -43,7 +43,11 @@ exports.chatNewMessage = async (hookName, context) => {
   msgElt.classList.add('ep_chat_log_join_leave-message');
   msgElt.dataset.l10nId = typeId;
   msgElt.append(defaultMsg[type]);
-  context.rendered = document.createElement('p');
+  // Etherpad core appends real chat messages to #chattext as <p>. Tests
+  // (and other plugins) often locate them with `#chattext p` in strict
+  // mode, which then trips on these synthetic join/leave entries.
+  // Render them as <div> so plain `p` selectors only match real chat.
+  context.rendered = document.createElement('div');
   context.rendered.classList.add(typeId);
   context.rendered.append(timeElt, nameElt, ' ', msgElt);
 

--- a/static/tests/frontend-new/specs/smoke.spec.ts
+++ b/static/tests/frontend-new/specs/smoke.spec.ts
@@ -10,4 +10,15 @@ test.describe('ep_chat_log_join_leave', () => {
     const padBody = await getPadBody(page);
     await expect(padBody).toBeVisible();
   });
+
+  // The join message should not be a <p>, so core / other-plugin tests
+  // that strict-mode-locate `#chattext p` (the user's actual chat) don't
+  // collide with the synthetic join entry. See change_user_color.spec.ts
+  // upstream for the failure mode. Chat is collapsed by default, so the
+  // entry isn't "visible" — assert presence instead.
+  test('join entry is rendered as a <div>, not a <p>', async ({page}) => {
+    await expect(page.locator('#chattext > div.ep_chat_log_join_leave-join'))
+        .toHaveCount(1, {timeout: 30_000});
+    await expect(page.locator('#chattext > p.ep_chat_log_join_leave-join')).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## Summary

The upstream Discord report had three failing official plugins. The plugin code itself was already fixed on `main` in `a87d8c7`, but the auto-publish gate kept failing because Etherpad core's `change_user_color.spec.ts` was tripping on the synthetic join entry:

```
strict mode violation: locator('#chattext').locator('p') resolved to 2 elements:
  1) <p data-author-id="..." class="ep_chat_log_join_leave-join ...">
  2) <p data-authorid="..." class="author-...">
```

Two fixes here:

1. **Render join/leave entries as `<div>`** instead of `<p>`. Core's chat code (`chat.ts:183`) just appends `ctx.rendered` as-is — it doesn't care about the element type — so the strict-mode `#chattext p` locator now only matches real chat. Existing class-based CSS selectors (`.ep_chat_log_join_leave-join`, etc.) are unaffected.

2. **Carry the chat-line block styling onto the `<div>`.** Both core (`pad/chat.css`) and the colibris skin style `#chattext p` directly with `padding: 4px 10px`, `pre-wrap`, `overflow-x: hidden`, `word-wrap: break-word`. Without these, the `<div>` rendered flush-left with no padding and looked out of place. The plugin stylesheet now sets the same rules on `.ep_chat_log_join_leave-join,-leave` so the entries sit flush with regular chat lines (kept the existing `font-size: smaller; font-style: italic` for the system-notice look).

## Test plan
- [x] New smoke specs assert the join entry is a `<div>` and no `<p.ep_chat_log_join_leave-join>` exists in `#chattext`.
- [x] Verified in-browser locally — formatting matches real chat lines, join entry remains visually distinct (italic, smaller).
- [ ] Plugin CI green.
- [ ] Auto-publish job actually fires — three commits ahead of v1.0.47, including the merged ChatMessage fix `a87d8c7` and PadUtils import fix `173ff84`. v1.0.48 should ship once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)