### PR TITLE
fix: suppress new-chat gritter for join/leave entries

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -24,13 +24,15 @@ exports.chatNewMessage = async (hookName, context) => {
   if (!['join', 'leave'].includes(type)) throw new Error(`Unexpected message type: ${type}`);
   const typeId = `ep_chat_log_join_leave-${type}`; // Used for classes and html10n.
 
-  // Because the default rendering is overridden below, context.text and context.authorName are
-  // ignored except for the gritter pop-up.
   if (!context.authorName) context.authorName = context.author;
-  const msgForGritter = document.createElement('span');
-  msgForGritter.dataset.l10nId = typeId;
-  msgForGritter.append(defaultMsg[type]);
-  context.text = msgForGritter.outerHTML;
+  // Suppress core's "new chat message" gritter (chat.ts triggers it whenever
+  // chat is closed and ctx.duration > 0). Join/leave events are not chat
+  // messages users sent, and surfacing them as gritters has surprising
+  // side-effects: the popup is often the first .gritter-item in the DOM, so
+  // unrelated tests that wait for a gritter (e.g. core's
+  // error_sanitization.spec) grab "unnamedjoined the pad" instead of the
+  // gritter they actually triggered.
+  context.duration = 0;
 
   // Override the default rendering.
   const timeElt = document.createElement('span');


### PR DESCRIPTION
## Summary

Follow-up to PR #82. Etherpad core's chat handler (`chat.ts:208-222`) pops a gritter for any new chat message when chat is closed and `ctx.duration > 0`. The plugin's join/leave entries are technically chat messages, so a gritter saying "unnamedjoined the pad" appeared on every pad load — surprising any unrelated test waiting for a gritter, e.g. core's `error_sanitization.spec.ts`:

```
Expected substring: "Please press and hold Ctrl and press F5 to reload this page"
Received string:    "unnamedjoined the pad"
```

Setting `ctx.duration = 0` in our `chatNewMessage` hook tells core to skip the gritter while keeping the entry in the chat log. Drop the now-unused `msgForGritter` span — `context.text` was only consumed by the gritter we just suppressed.

## Why this PR exists

PR #82 merged via the repo's automerge config even though the frontend job was red, so the post-merge `Node.js Package` run on `main` is also red and the auto-publish job is being skipped. Latest tag is still v1.0.47 — none of the unreleased fixes (`a87d8c7`, `173ff84`, plus PR #82's `<div>` change) are on npm yet. This PR unblocks that.

## Test plan
- [x] All four `error_sanitization.spec.ts` tests pass locally with the patched plugin loaded.
- [x] Plugin smoke tests still pass.
- [ ] Plugin CI green.
- [ ] Auto-publish ships v1.0.48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)