### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,10 @@ const ChatMessage = (() => {
   }
 })();
 const assert = require('assert').strict;
-const log4js = require('ep_etherpad-lite/node_modules/log4js');
+const {createLogger} = require('ep_plugin_helpers/logger');
 const padMessageHandler = require('ep_etherpad-lite/node/handler/PadMessageHandler');
 
-const logger = log4js.getLogger('ep_chat_log_join_leave');
+const logger = createLogger('ep_chat_log_join_leave');
 
 if (ChatMessage == null) {
   logger.error('This version of Etherpad is unsupported. ' +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_chat_log_join_leave",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "Etherpad plugin to log user joins and leaves in the chat history",
   "main": "index.js",
   "scripts": {
@@ -33,5 +33,8 @@
   "funding": {
     "type": "individual",
     "url": "https://etherpad.org/"
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.6.7"
   }
 }


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Migrate log4js from `require("ep_etherpad-lite/node_modules/log4js")` to `ep_plugin_helpers/logger`

This change is **backward-compatible** with the current CJS etherpad release.